### PR TITLE
i2c: fix multi-byte reads, timeouts, setClock and NACK reporting

### DIFF
--- a/cores/sg200x/bsp/drivers/csi_iic.c
+++ b/cores/sg200x/bsp/drivers/csi_iic.c
@@ -706,6 +706,25 @@ csi_error_t csi_iic_dev_addr(csi_iic_t *iic, uint32_t dev_addr)
     dw_iic_enable(iic_base);
     return ret;
 }
+static int32_t iic_check_abort(dw_iic_regs_t *iic_base)
+{
+    uint32_t source = dw_iic_take_abort_source(iic_base);
+
+    if (!source) {
+        return 0;
+    }
+
+    if (source & DW_IIC_TX_ABRT_7B_ADDR_NOACK) {
+        return CSI_IIC_ADDR_NACK;
+    }
+
+    if (source & DW_IIC_TX_ABRT_TXDATA_NOACK) {
+        return CSI_IIC_DATA_NACK;
+    }
+
+    return CSI_ERROR;
+}
+
 /**
   \brief       Start sending data as IIC Master.
                This function is blocking
@@ -720,7 +739,8 @@ int32_t csi_iic_master_send(csi_iic_t *iic, uint32_t devaddr, const void *data, 
 {
     CSI_PARAM_CHK(iic, CSI_ERROR);
     CSI_PARAM_CHK(data, CSI_ERROR);
-    csi_error_t ret = CSI_OK;
+    int32_t ret = CSI_OK;
+    int32_t abort_ret;
     uint64_t timestart;
     int32_t send_count = size;
     uint8_t *send_data = (uint8_t *)data;
@@ -757,6 +777,11 @@ int32_t csi_iic_master_send(csi_iic_t *iic, uint32_t devaddr, const void *data, 
         if (dw_iic_xfer_finish(iic_base)) {
             ret = CSI_ERROR;
         }
+
+        if ((abort_ret = iic_check_abort(iic_base)) != 0) {
+            ret = abort_ret;
+        }
+
         goto SEND_ERROR;
     }
 
@@ -783,7 +808,8 @@ int32_t csi_iic_master_receive(csi_iic_t *iic, uint32_t devaddr, void *data, uin
 {
     CSI_PARAM_CHK(iic, CSI_ERROR);
     CSI_PARAM_CHK(data, CSI_ERROR);
-    csi_error_t ret = CSI_OK;
+    int32_t ret = CSI_OK;
+    int32_t abort_ret;
     uint64_t timestart;
     int32_t queued = 0, received = 0;
     uint8_t *receive_data = (uint8_t *)data;
@@ -818,6 +844,9 @@ int32_t csi_iic_master_receive(csi_iic_t *iic, uint32_t devaddr, void *data, uin
         if (iic_base->IC_STATUS & DW_IIC_RXFIFO_NOT_EMPTY_STATE) {
             *receive_data++ = dw_iic_receive_data(iic_base);
             received++;
+        } else if ((abort_ret = iic_check_abort(iic_base)) != 0) {
+            ret = abort_ret;
+            goto RECV_ERROR;
         } else if ((millis() - timestart) > timeout) {
             pr_debug("Timeout for waiting ic status RFNE\n");
             ret = CSI_TIMEOUT;
@@ -829,6 +858,11 @@ int32_t csi_iic_master_receive(csi_iic_t *iic, uint32_t devaddr, void *data, uin
         if (dw_iic_xfer_finish(iic_base)) {
             ret = CSI_ERROR;
         }
+
+        if ((abort_ret = iic_check_abort(iic_base)) != 0) {
+            ret = abort_ret;
+        }
+
         goto RECV_ERROR;
     }
 

--- a/cores/sg200x/bsp/drivers/csi_iic.c
+++ b/cores/sg200x/bsp/drivers/csi_iic.c
@@ -785,7 +785,7 @@ int32_t csi_iic_master_receive(csi_iic_t *iic, uint32_t devaddr, void *data, uin
     CSI_PARAM_CHK(data, CSI_ERROR);
     csi_error_t ret = CSI_OK;
     uint32_t timecount;
-    int32_t read_count = size, active = 0;
+    int32_t queued = 0, received = 0;
     uint8_t *receive_data = (uint8_t *)data;
     uint8_t iic_idx = HANDLE_DEV_IDX(iic);
     dw_iic_regs_t *iic_base = (dw_iic_regs_t *)HANDLE_REG_BASE(iic);
@@ -802,26 +802,22 @@ int32_t csi_iic_master_receive(csi_iic_t *iic, uint32_t devaddr, void *data, uin
 
     timecount = timeout + millis();
 
-    while (read_count) {
-        if (!active) {
-            /*
-            * Avoid writing to ic_cmd_data multiple times
-            * in case this loop spins too quickly and the
-            * ic_status RFNE bit isn't set after the first
-            * write. Subsequent writes to ic_cmd_data can
-            * trigger spurious i2c transfer.
-            */
-            dw_iic_transmit_data(iic_base, DW_IIC_DATA_CMD | (stop ? DW_IIC_DATA_STOP : DW_IIC_DATA_RESTART));
-            //mmio_write_32((uintptr_t)&i2c_base->ic_cmd_data, (dev <<1) | BIT_I2C_CMD_DATA_READ_BIT | BIT_I2C_CMD_DATA_STOP_BIT);
-            active = 1;
+    while (received < (int32_t)size) {
+        while ((queued < (int32_t)size) &&
+               (iic_base->IC_STATUS & DW_IIC_TXFIFO_NOT_FULL_STATE)) {
+            uint32_t cmd = DW_IIC_DATA_CMD;
+
+            if (stop && (queued == (int32_t)size - 1)) {
+                cmd |= DW_IIC_DATA_STOP;
+            }
+
+            dw_iic_transmit_data(iic_base, cmd);
+            queued++;
         }
 
-        //if (iic_base->IC_RAW_INTR_STAT & DW_IIC_RAW_RX_FULL) {
         if (iic_base->IC_STATUS & DW_IIC_RXFIFO_NOT_EMPTY_STATE) {
-        //if (dw_iic_get_receive_fifo_num(iic_base)) {
             *receive_data++ = dw_iic_receive_data(iic_base);
-            read_count--;
-            active = 0;
+            received++;
         } else if (millis() >= timecount) {
             pr_debug("Timeout for waiting ic status RFNE\n");
             ret = CSI_TIMEOUT;

--- a/cores/sg200x/bsp/drivers/csi_iic.c
+++ b/cores/sg200x/bsp/drivers/csi_iic.c
@@ -25,10 +25,10 @@ static csi_error_t wait_iic_transmit(dw_iic_regs_t *iic_base, uint32_t timeout)
     csi_error_t ret = CSI_OK;
 
     do {
-        uint32_t timecount = timeout + millis();
+        uint64_t timestart = millis();
 
         while ((dw_iic_get_transmit_fifo_num(iic_base) != 0U) && (ret == CSI_OK)) {
-            if (millis() >= timecount) {
+            if ((millis() - timestart) > timeout) {
                 ret = CSI_TIMEOUT;
             }
         }
@@ -44,10 +44,10 @@ void wait_iic_transmit_fifo_empty(dw_iic_regs_t *iic_base, uint32_t timeout)
     csi_error_t ret = CSI_OK;
 
     do {
-        uint32_t timecount = timeout + millis();
+        uint64_t timestart = millis();
 
         while ((dw_iic_get_transmit_fifo_num(iic_base) != 0U) && (ret == CSI_OK)) {
-            if (millis() >= timecount) {
+            if ((millis() - timestart) > timeout) {
                 ret = CSI_TIMEOUT;
             }
         }
@@ -68,10 +68,10 @@ static csi_error_t wait_iic_receive(dw_iic_regs_t *iic_base, uint32_t wait_data_
     csi_error_t ret = CSI_OK;
 
     do {
-        uint32_t timecount = timeout + millis();
+        uint64_t timestart = millis();
 
         while ((dw_iic_get_receive_fifo_num(iic_base) < wait_data_num) && (ret == CSI_OK)) {
-            if (millis() >= timecount) {
+            if ((millis() - timestart) > timeout) {
                 ret = CSI_TIMEOUT;
             }
         }
@@ -721,7 +721,7 @@ int32_t csi_iic_master_send(csi_iic_t *iic, uint32_t devaddr, const void *data, 
     CSI_PARAM_CHK(iic, CSI_ERROR);
     CSI_PARAM_CHK(data, CSI_ERROR);
     csi_error_t ret = CSI_OK;
-    uint32_t timecount;
+    uint64_t timestart;
     int32_t send_count = size;
     uint8_t *send_data = (uint8_t *)data;
     uint8_t iic_idx = HANDLE_DEV_IDX(iic);
@@ -737,7 +737,7 @@ int32_t csi_iic_master_send(csi_iic_t *iic, uint32_t devaddr, const void *data, 
     dw_iic_set_target_address(iic_base, devaddr);
     dw_iic_enable(iic_base);
 
-    timecount = timeout + millis();
+    timestart = millis();
 
     while (send_count) {
         if (iic_base->IC_STATUS & DW_IIC_TXFIFO_NOT_FULL_STATE) {
@@ -746,7 +746,7 @@ int32_t csi_iic_master_send(csi_iic_t *iic, uint32_t devaddr, const void *data, 
             } else {
                 dw_iic_transmit_data(iic_base, *send_data++);
             }
-        } else if (millis() >= timecount) {
+        } else if ((millis() - timestart) > timeout) {
             pr_debug("Timeout for waiting ic status TFNF\n");
             ret = CSI_TIMEOUT;
             goto SEND_ERROR;
@@ -784,7 +784,7 @@ int32_t csi_iic_master_receive(csi_iic_t *iic, uint32_t devaddr, void *data, uin
     CSI_PARAM_CHK(iic, CSI_ERROR);
     CSI_PARAM_CHK(data, CSI_ERROR);
     csi_error_t ret = CSI_OK;
-    uint32_t timecount;
+    uint64_t timestart;
     int32_t queued = 0, received = 0;
     uint8_t *receive_data = (uint8_t *)data;
     uint8_t iic_idx = HANDLE_DEV_IDX(iic);
@@ -800,7 +800,7 @@ int32_t csi_iic_master_receive(csi_iic_t *iic, uint32_t devaddr, void *data, uin
     dw_iic_set_target_address(iic_base, devaddr);
     dw_iic_enable(iic_base);
 
-    timecount = timeout + millis();
+    timestart = millis();
 
     while (received < (int32_t)size) {
         while ((queued < (int32_t)size) &&
@@ -818,7 +818,7 @@ int32_t csi_iic_master_receive(csi_iic_t *iic, uint32_t devaddr, void *data, uin
         if (iic_base->IC_STATUS & DW_IIC_RXFIFO_NOT_EMPTY_STATE) {
             *receive_data++ = dw_iic_receive_data(iic_base);
             received++;
-        } else if (millis() >= timecount) {
+        } else if ((millis() - timestart) > timeout) {
             pr_debug("Timeout for waiting ic status RFNE\n");
             ret = CSI_TIMEOUT;
             goto RECV_ERROR;
@@ -1035,7 +1035,7 @@ int32_t csi_iic_mem_send(csi_iic_t *iic, uint32_t devaddr, uint16_t memaddr, csi
     CSI_PARAM_CHK(iic, CSI_ERROR);
     CSI_PARAM_CHK(data, CSI_ERROR);
     csi_error_t ret = CSI_OK;
-    uint32_t timecount;
+    uint64_t timestart;
     uint32_t send_count = size;
     uint8_t *send_data = (uint8_t *)data;
     uint8_t memaddr_len;
@@ -1063,7 +1063,7 @@ int32_t csi_iic_mem_send(csi_iic_t *iic, uint32_t devaddr, uint16_t memaddr, csi
         goto SEND_ERROR;
     }
 
-    timecount = timeout + millis();
+    timestart = millis();
 
     while (send_count > 0) {
         if (iic_base->IC_STATUS & DW_IIC_TXFIFO_NOT_FULL_STATE) {
@@ -1074,7 +1074,7 @@ int32_t csi_iic_mem_send(csi_iic_t *iic, uint32_t devaddr, uint16_t memaddr, csi
                 dw_iic_transmit_data(iic_base, *send_data++);
                 pr_debug("send_count != 0\n");
             }
-        } else if (millis() >= timecount) {
+        } else if ((millis() - timestart) > timeout) {
             pr_debug("ic status is not TFNF\n");
             ret = CSI_TIMEOUT;
             goto SEND_ERROR;
@@ -1109,7 +1109,7 @@ int32_t csi_iic_mem_receive(csi_iic_t *iic, uint32_t devaddr, uint16_t memaddr, 
     CSI_PARAM_CHK(iic, CSI_ERROR);
     CSI_PARAM_CHK(data, CSI_ERROR);
     csi_error_t ret = CSI_OK;
-    uint32_t timecount;
+    uint64_t timestart;
     int recv_count = size;
     uint8_t *recv_data = (uint8_t *)data;
     uint8_t memaddr_len;
@@ -1137,7 +1137,7 @@ int32_t csi_iic_mem_receive(csi_iic_t *iic, uint32_t devaddr, uint16_t memaddr, 
         ret = CSI_ERROR;
         goto RECV_ERROR;
     }
-    timecount = timeout + millis();
+    timestart = millis();
     for (int i = 0 ; i < recv_count; i ++) {
         if (i != (recv_count -1)) {
             dw_iic_transmit_data(iic_base, DW_IIC_DATA_CMD);
@@ -1151,7 +1151,7 @@ int32_t csi_iic_mem_receive(csi_iic_t *iic, uint32_t devaddr, uint16_t memaddr, 
         //if (dw_iic_get_receive_fifo_num(iic_base)) {
             *recv_data++ = dw_iic_receive_data(iic_base);
             --recv_count;
-        } else if (millis() >= timecount) {
+        } else if ((millis() - timestart) > timeout) {
             pr_debug("Timed out read ic_cmd_data\n");
             ret = CSI_TIMEOUT;
             goto RECV_ERROR;
@@ -1193,10 +1193,10 @@ int32_t csi_iic_slave_send(csi_iic_t *iic, const void *data, uint32_t size, uint
         uint32_t intr_state;
         iic_base = (dw_iic_regs_t *)HANDLE_REG_BASE(iic);
         dw_iic_enable(iic_base);
-        uint32_t timecount = millis() + timeout;
+        uint64_t timestart = millis();
 
         while (1) {
-            if (millis() >= timecount) {
+            if ((millis() - timestart) > timeout) {
                 break;
             }
 

--- a/cores/sg200x/bsp/include/csi/csi_iic.h
+++ b/cores/sg200x/bsp/include/csi/csi_iic.h
@@ -64,6 +64,10 @@ typedef enum {
     IIC_EVENT_ERROR                          ///< The receive buffer was completely filled to FIFO and more data arrived. That data is lost
 } csi_iic_event_t;
 
+/* not csi_error_t: master send/receive return a byte count on success */
+#define CSI_IIC_ADDR_NACK   (-16)
+#define CSI_IIC_DATA_NACK   (-17)
+
 /**
   \struct      csi_iic_t
   \brief       iic ctrl block

--- a/cores/sg200x/bsp/include/hal/dw/dw_iic_ll.h
+++ b/cores/sg200x/bsp/include/hal/dw/dw_iic_ll.h
@@ -486,6 +486,19 @@ static inline void dw_iic_flush_rxfifo(dw_iic_regs_t *iic_base)
 		iic_base->IC_DATA_CMD;
 }
 
+/* Abort source, or 0. Clears it so it cannot leak into the next transfer. */
+static inline uint32_t dw_iic_take_abort_source(dw_iic_regs_t *iic_base)
+{
+    uint32_t source = 0U;
+
+    if (iic_base->IC_RAW_INTR_STAT & DW_IIC_RAW_TX_ABRT) {
+        source = iic_base->IC_TX_ABRT_SOURCE;
+        iic_base->IC_CLR_TX_ABRT;
+    }
+
+    return source;
+}
+
 static inline void dw_iic_set_slave_10bit_addr_mode(dw_iic_regs_t *iic_base)
 {
     iic_base->IC_CON |= DW_IIC_CON_SLAVE_ADDR_MODE;

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -193,16 +193,21 @@ uint8_t TwoWire::endTransmission(bool stopBit)
     }
 
     int ret = csi_iic_master_send(&_iic, txAddress, data, i, _timeout, stopBit);
+    if (ret > 0) {
+        return 0;
+    }
+
     switch (ret) {
     case CSI_OK:
         return 0;
+    case CSI_IIC_ADDR_NACK:
+        return 2;
+    case CSI_IIC_DATA_NACK:
+        return 3;
     case CSI_TIMEOUT:
         return 5;
     default:
-	if (ret > 0)
-            return 0;
-        else
-	    return 4;
+        return 4;
     }
 
     return 0;

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -105,12 +105,12 @@ void TwoWire::begin(uint16_t address, csi_iic_addr_mode_t addr_mode)
 void TwoWire::setClock(uint32_t baudrate)
 {
     csi_iic_speed_t speed = IIC_BUS_SPEED_HIGH;
-    if (baudrate <= 1000000) {
-        speed = IIC_BUS_SPEED_FAST_PLUS;
+    if (baudrate <= 100000) {
+        speed = IIC_BUS_SPEED_STANDARD;
     } else if (baudrate <= 400000) {
         speed = IIC_BUS_SPEED_FAST;
-    } else if (baudrate <= 100000) {
-        speed = IIC_BUS_SPEED_STANDARD;
+    } else if (baudrate <= 1000000) {
+        speed = IIC_BUS_SPEED_FAST_PLUS;
     }
     csi_iic_speed(&_iic, speed);
 }


### PR DESCRIPTION
Four I2C master fixes, found while using an AHT30 whose reads returned its status six times instead of a measurement.

**1:** `i2c: fix multi-byte master receive` - every read carried a STOP, so an n byte read went out as n one byte transactions, and devices that restart their output on a repeated address return the same byte each time. An MPU-6050, for example, hides this since it keeps its register pointer across transactions.

---
## Before:
<img width="1976" height="475" alt="image" src="https://github.com/user-attachments/assets/3108a1f0-287c-46af-b3e1-ae0b21657bc7" />

```
data: 18 18 18 18 18 18
```

---
## After:
<img width="2416" height="478" alt="image" src="https://github.com/user-attachments/assets/49435155-46c4-4bda-ac3b-784d17813cf8" />

```
data:  18 64 6F 86 44 68 75      39.2 %RH, 28.3 C, CRC ok
```
---

**2:** `i2c: fix timeout arithmetic overflow` - `timeout + millis()` was truncated to `uint32_t`, so Wire's `-1` default wrapped to `millis() - 1`, so every `requestFrom()` returned `-3`.

**3:** `wire: fix setClock speed selection` - The widest range was tested first, so 100kHz selected `FAST_PLUS`, which `csi_iic_speed()` rejects without touching a register. So just a reorder.

**4:** `i2c: report NACK from endTransmission` - nothing read `IC_TX_ABRT_SOURCE`, so writes to an absent device reported success and reads waited the full timeout. Now returns the Arduino codes (absent 2, data NACK
3, present 0).

Tested on a Milk-V Duo (CV1800B), I2C0, with an AHT30, QMC5883L and MPU-6050.

Not touched: `FAST_PLUS` is unimplemented and high speed mode is untested as nothing here runs above 400kHz.